### PR TITLE
feat: don't download puppeteer in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /opt/app
 COPY package.json .
 COPY yarn.lock .
 
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
 RUN yarn install --frozen-lockfile
 
 COPY ./src ./src
@@ -15,7 +17,9 @@ FROM node:16-buster-slim
 WORKDIR /opt/app
 
 ARG NODE_ENV=production
+
 ENV NODE_ENV=${NODE_ENV}
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 COPY package.json .
 COPY yarn.lock .


### PR DESCRIPTION
make our builds zoom faster

![image](https://user-images.githubusercontent.com/55610086/133701544-3772b663-fb03-4cde-a588-e1d271ee208a.png)
checks out to me, that's a free 400mb saved on the image